### PR TITLE
Nav mobile

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import "../public/styles.css";
 import Header from "../components/Header";
+import Nav from "../components/Nav";
 
 export default function RootLayout({
   children, // will be a page or nested layout
@@ -19,7 +20,8 @@ export default function RootLayout({
         <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
         <title>Richard Choi</title>
       </head>
-      <body className="bg-black">
+      <body className="bg-black flex flex-col items-center">
+        <Nav/>
         <Header />
         {children}
       </body>

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -8,10 +8,10 @@ export default function Nav(){
     const [toggleMenu, setToggleMenu] = useState("hidden");
 
     return(
-        <nav className = "fixed flex flex-col self-end p-4 bg-black">
-            <IoIosMenu className = {`text-6xl ${toggleMenu === 'hidden' ? "" : "hidden"}`} onClick = {()=>setToggleMenu("block")}/>
+        <nav className = "fixed hidden flex-col self-end bg-black w-full max-[800px]:flex">
+            <IoIosMenu className = {`text-6xl self-end ${toggleMenu === 'hidden' ? "" : "hidden"}`} onClick = {()=>setToggleMenu("flex")}/>
             <IoIosClose className = {`text-6xl self-end ${toggleMenu === 'hidden' ? "hidden" : ""}`} onClick = {()=>setToggleMenu("hidden")}/>
-            <ul className = {toggleMenu}>
+            <ul className = {`${toggleMenu} items-center flex-col pb-4 px-4`}>
                 <li className = "mb-2"><Link className = "text-4xl" href = "#myProject">My Project</Link></li>
                 <li><Link className = "text-4xl" href = "#documentation">Documentation</Link></li>
             </ul>

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,0 +1,20 @@
+"use client"
+import Link from "next/link";
+import { IoIosMenu, IoIosClose } from "react-icons/io";
+import { useState } from "react";
+
+export default function Nav(){
+
+    const [toggleMenu, setToggleMenu] = useState("hidden");
+
+    return(
+        <nav className = "fixed flex flex-col self-end p-4 bg-black">
+            <IoIosMenu className = {`text-6xl ${toggleMenu === 'hidden' ? "" : "hidden"}`} onClick = {()=>setToggleMenu("block")}/>
+            <IoIosClose className = {`text-6xl self-end ${toggleMenu === 'hidden' ? "hidden" : ""}`} onClick = {()=>setToggleMenu("hidden")}/>
+            <ul className = {toggleMenu}>
+                <li className = "mb-2"><Link className = "text-4xl" href = "#myProject">My Project</Link></li>
+                <li><Link className = "text-4xl" href = "#documentation">Documentation</Link></li>
+            </ul>
+        </nav>
+    )
+}

--- a/components/Project.tsx
+++ b/components/Project.tsx
@@ -43,7 +43,7 @@ export default function Project() {
   };
 
   return (
-    <section id="myProjects" className="flex flex-col items-left p-2">
+    <section id="myProject" className="flex flex-col items-left p-2">
       <h2 className="text-6xl my-12 px-5">Projects</h2>
       <section className="flex flex-col items-center">
         {


### PR DESCRIPTION
Add nav bar on mobile view for easy navigation between sections
make nav bar fixed so it stays visible on the site as the user scrolls

A bit torn betwen the styling for the nav bar, going with v2 for now

When navbar is open v1:
![Screenshot 2024-04-02 134042](https://github.com/choir27/Richard-Choi-Tailwind-Application/assets/66279068/74864713-d50d-4663-9e70-f26ac8420690)

When navbar is open v2:
![Screenshot 2024-04-02 133819](https://github.com/choir27/Richard-Choi-Tailwind-Application/assets/66279068/939b40c8-63ba-4d6e-abd4-e0f42217e6ba)

When navbar is closed: 

![Screenshot 2024-04-02 133803](https://github.com/choir27/Richard-Choi-Tailwind-Application/assets/66279068/dc584dd8-64f0-455d-885e-a11a691e0b14)
